### PR TITLE
Made changes and improvements

### DIFF
--- a/src/index.did
+++ b/src/index.did
@@ -1,21 +1,18 @@
 type User = record {
-  id : text;
   username : text;
-  password : text;
   createdAt : nat64;
+  secret : text;
   email : text;
-  resetToken : opt text;
 };
-type UserPayload = record { username : text; password : text; email : text };
+type UserPayload = record { username : text; secret : text; email : text };
 type _AzleResult = variant { Ok : User; Err : text };
 type _AzleResult_1 = variant { Ok : vec User; Err : text };
 type _AzleResult_2 = variant { Ok : text; Err : text };
-service : () -> {
+service : (text) -> {
   deleteUser : (text) -> (_AzleResult);
   getUser : (text) -> (_AzleResult) query;
   getUsers : () -> (_AzleResult_1) query;
-  loginUser : (text, text) -> (_AzleResult) query;
+  loginUser : () -> (_AzleResult) query;
+  reclaimAccount : (text, text) -> (_AzleResult_2);
   registerUser : (UserPayload) -> (_AzleResult);
-  requestPasswordReset : (text) -> (_AzleResult_2);
-  resetPassword : (text, text) -> (_AzleResult);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,115 +1,107 @@
-import { $query, $update, Record, StableBTreeMap, Vec, match, Result, nat64, ic, Opt } from 'azle';
+import { $query, $update, Record, StableBTreeMap, Vec, match, Result, nat64,Principal, ic, Opt, $init } from 'azle';
 import { v4 as uuidv4 } from 'uuid';
 
-
+//Record to describe the details about the user
 type User = Record<{
-  id: string;
   username: string;
   email: string;
-  password: string;
+  secret: string;
   createdAt: nat64;
-  resetToken: Opt<string>;
 }>
 
 type UserPayload = Record<{
   username: string;
   email: string;
-  password: string;
+  secret: string
 }>
+//variable to store the Principal ID of the canister admin
+let adminPrincipal : Principal;
 
-const userStorage = new StableBTreeMap<string, User>(0, 44, 1024);
+//map to store the users in the canister
+const userStorage = new StableBTreeMap<Principal, User>(0, 44, 1024);
 
+
+//initlalize the admin on deployment
+$init;
+export function init(admin : string) : void{
+  adminPrincipal = Principal.fromText(admin)
+}
+
+
+
+//return all registered users from the canister
 $query;
 export function getUsers(): Result<Vec<User>, string> {
   return Result.Ok(userStorage.values());
 }
 
+
+//get the details of the user associated with a specific Principal ID
 $query;
 export function getUser(id: string): Result<User, string> {
-  return match(userStorage.get(id), {
+  const user = Principal.fromText(id);
+  return match(userStorage.get((user)), {
     Some: (user) => Result.Ok<User, string>(user),
-    None: () => Result.Err<User, string>(`User with id=${id} not found`)
+    None: () => Result.Err<User, string>(`User dont have an account registered yet`)
   });
 }
 
+
+//Register the user to the canister
 $update;
 export function registerUser(payload: UserPayload): Result<User, string> {
+  const caller = ic.caller();
+  if(caller.toString() === "2vxsx-fae"){
+    return Result.Err<User,string>("Anonymous users are not allowed to register accounts")
+  }
   const user: User = {
-    id: uuidv4(),
     createdAt: ic.time(),
-    resetToken: Opt.None,
     ...payload
   };
-  userStorage.insert(user.id, user);
+  userStorage.insert(caller, user);
   return Result.Ok(user);
 }
 
-$query;
-export function loginUser(username: string, password: string): Result<User, string> {
-  const user = userStorage.values().find((u) => u.username === username && u.password === password);
-  if (user) {
-    return Result.Ok(user);
-  }
-  return Result.Err<User, string>('Invalid username or password');
-}
 
-$update;
-export function deleteUser(id: string): Result<User, string> {
-  return match(userStorage.remove(id), {
-    Some: (deletedUser) => Result.Ok<User, string>(deletedUser),
-    None: () => Result.Err<User, string>(`User with id=${id} not found`)
+// let the user login using their Principal ID
+$query;
+export function loginUser(): Result<User, string> {
+  const caller = ic.caller();
+  return match(userStorage.get(caller),{
+    None : ()=>{ return Result.Err<User,string>("You dont have an account yet")},
+    Some : (user)=>{ return Result.Ok<User,string>(user)}
   });
 }
 
+
+//Only admin is allowed to delete an account
 $update;
-export function requestPasswordReset(email: string): Result<string, string> {
-  const user = userStorage.values().find((u) => u.email === email);
-  if (user) {
-    const resetToken = generateResetToken();
-    userStorage.insert(user.id, { ...user, resetToken: Opt.Some(resetToken) });
-    return Result.Ok(resetToken);
+export function deleteUser(id: string): Result<User, string> {
+  const caller = ic.caller();
+  if(caller === adminPrincipal){
+
+    return match(userStorage.remove(Principal.fromText(id)), {
+      Some: (deletedUser) => Result.Ok<User, string>(deletedUser),
+      None: () => Result.Err<User, string>(`User with Principal Id=${id} not found`)
+    });
   }
-  return Result.Err<string, string>('User with the specified email not found');
+  return Result.Err<User,string>("You are not authorized")
 }
 
+
+//reclaim an old account by providing the secret associated with it
 $update;
-export function resetPassword(resetToken: string, newPassword: string): Result<User, string> {
-  const user = userStorage.values().find((u) => match(u.resetToken, {
-    Some: (value:string) => value === resetToken,
-    None: () => false
-  }));
+export function reclaimAccount( account : string, secret : string): Result<string,string>{
+  const caller = ic.caller();
+  return match(userStorage.get(Principal.fromText(account)),{
 
-
-  if (user) {
-    const updatedUser = { ...user, password: newPassword, resetToken: Opt.None };
-    userStorage.insert(user.id, updatedUser);
-    return Result.Ok(updatedUser);
-  }
-  return Result.Err<User, string>('Invalid or expired reset token');
-}
-
-// Helper function to generate a random reset token
-function generateResetToken(): string {
-  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  let result = '';
-
-  for (let i = 0; i < 5; i++) {
-    const randomIndex = Math.floor(Math.random() * characters.length);
-    result += characters.charAt(randomIndex);
-  }
-
-  return result;
-}
-
-// a workaround to make uuid package work with Azle
-globalThis.crypto = {
-    getRandomValues: () => {
-        let array = new Uint8Array(32)
-
-        for (let i = 0; i < array.length; i++) {
-            array[i] = Math.floor(Math.random() * 256)
-        }
-
-        return array
-    }
+    None : ()=>{ return Result.Err<string,string>("This account does not exist")},
+    Some : (oldAccount)=>{
+      if(oldAccount.secret === secret){
+        userStorage.insert(caller, oldAccount);
+        return Result.Ok<string,string>("Your account details have been restored, you can now login with the current Principal ID")
+      }
+      return Result.Err<string,string>("The secrets dont match, try again later")
+     }
+  });
 }


### PR DESCRIPTION

- added `init` function to initialize the admin on deployment
- Emails and passwords are common login methods in web2, in web2 there is a notion of logging in with addresses and IDs, i have modified the login function to let the user login with their Principal ID, which is a unique identifier for every user on the Internet Computer.
- added checks in the `deleteUser` function to allow only the admin to delete accounts
- added a new fucntion `reclaimAccount`. This allows the user to reclaim their old account by providing the secret associated with the old account. Once they have reclaimed the account, they will be able to login with their new Principal ID
- modified the `userStorage` map to use the Principal IDs as the key. this provides a unique and scallable method to identify user accounts
